### PR TITLE
Sign In translated into Jade

### DIFF
--- a/itu-minitwit-node/src/routes/signin.js
+++ b/itu-minitwit-node/src/routes/signin.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 router.get('/', function(req, res, next) {
-  res.render('signin');
+  res.render('signin', { title: 'MiniTwit' });
 });
 
 module.exports = router;

--- a/itu-minitwit-node/src/views/index.jade
+++ b/itu-minitwit-node/src/views/index.jade
@@ -1,21 +1,4 @@
-doctype html
-html
-  head
-    title= title
-    link(rel='stylesheet', href='/stylesheets/style.css')
-  body
-    .page
-      h1= title
+extends layout
 
-      .navigation
-        a(href="{{ url_for('timeline') }}") public timeline
-        |  |  
-        a(href="/signup") sign up
-        |  |  
-        a(href="signin") sign in
-
-      .body
-        include timeline.jade  
-
-      .footer
-         MiniTwit — A NodeJS project
+block content
+  include timeline.jade

--- a/itu-minitwit-node/src/views/layout.jade
+++ b/itu-minitwit-node/src/views/layout.jade
@@ -1,0 +1,22 @@
+doctype html
+html
+  head
+    title= title
+    link(rel='stylesheet', href='/stylesheets/style.css')
+  body
+    .page
+      h1= title
+
+      .navigation
+        a(href="{{ url_for('timeline') }}") public timeline
+        |  |  
+        a(href="/signup") sign up
+        |  |  
+        a(href="signin") sign in
+
+    
+      .body
+        block content  
+
+      .footer
+         MiniTwit — A NodeJS project

--- a/itu-minitwit-node/src/views/signin.jade
+++ b/itu-minitwit-node/src/views/signin.jade
@@ -1,1 +1,18 @@
-p hejkjadhsdla
+extends layout
+
+block content
+    h2 Sign In
+    .signin-form
+        form(action='' method='post')
+    dl
+        dt
+        | Username:
+        dd
+        input(type='text' name='username' size='30' value="")
+        dt
+        | Password:
+        dd
+        input(type='password' name='password' size='30')
+    .actions
+        input(type='submit' value='Sign In')
+


### PR DESCRIPTION
-translated Sign in jade from the original HTML

- created layout.jade for easier implementation of styling across minitwit

- currently the login page is not functional. next step will be to implement the *“post”* method from the original minitwit.  issue #15 

more details [here](https://www.notion.so/DevOps-Group-S-5a3355635ff5417c985d66aff7d71124?p=925e44945c964415a9887358263b8e06&pm=s)

solves issue #7 

(OBS: Could not move the status of the issue in the project since I miss admin access) 