### PR TITLE
W4 timeline redirect

### DIFF
--- a/itu-minitwit-node/src/views/layout.jade
+++ b/itu-minitwit-node/src/views/layout.jade
@@ -8,7 +8,7 @@ html
       h1= title
 
       .navigation
-        a(href="{{ url_for('timeline') }}") public timeline
+        a(href="/timeline") public timeline
         |  |  
         a(href="/signup") sign up
         |  |  

--- a/itu-minitwit-node/src/views/layout.jade
+++ b/itu-minitwit-node/src/views/layout.jade
@@ -8,9 +8,9 @@ html
       h1= title
 
       .navigation
-        a(href="/timeline") public timeline
+        a(href="/") public timeline
         |  |  
-        a(href="/signup") sign up
+        a(href="signup") sign up
         |  |  
         a(href="signin") sign in
 


### PR DESCRIPTION
-fixed redirect links on header for public timeline 
(e.g. when clicking on sign in, clicking back on "public timeline" now succesfully redirects back)