### PR TITLE
redirecting to /api and sending status code 200

### DIFF
--- a/itu-minitwit-node/src/routes/message.js
+++ b/itu-minitwit-node/src/routes/message.js
@@ -60,8 +60,9 @@ router.post('/', function (req, res, next) {
       const hostname = os.hostname();
       logger.log('info', { url: req.url, method: req.method, requestBody: req.body, responseStatus: 200, message: req.body.text, hostname: hostname });
       req.session.flash = 'Your message was recorded';
-      res.send('message ' + req.body.text + ' created');
-      return;
+      //res.send('message ' + req.body.text + ' created');
+      res.status(200);
+      res.redirect('/api');
     })
 
   } else {


### PR DESCRIPTION
After posting a message once user is logged in, we were not sending a response, leaving the API pending.

Emi implemented a res.send with related message but unfortunately after that, header will change and wont be able to execute res.redirect(/api)

solution has then been to send an api response 200 and then redirecting, without the message. 



Apparently, that is a known limitation in res for node. see [here](https://itecnote.com/tecnote/node-js-res-send-then-res-redirect/) 